### PR TITLE
Add (A)syncVectorEnv support for sub-envs with different observation spaces

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -115,7 +115,7 @@ register(
 )
 
 register(
-    id="CarRacing-v3",
+    id="CarRacing-v2",
     entry_point="gymnasium.envs.box2d.car_racing:CarRacing",
     max_episode_steps=1000,
     reward_threshold=900,

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -153,9 +153,9 @@ class CarRacing(gym.Env, EzPickle):
 
     ```python
     >>> import gymnasium as gym
-    >>> env = gym.make("CarRacing-v3", render_mode="rgb_array", lap_complete_percent=0.95, domain_randomize=False, continuous=False)
+    >>> env = gym.make("CarRacing-v2", render_mode="rgb_array", lap_complete_percent=0.95, domain_randomize=False, continuous=False)
     >>> env
-    <TimeLimit<OrderEnforcing<PassiveEnvChecker<CarRacing<CarRacing-v3>>>>>
+    <TimeLimit<OrderEnforcing<PassiveEnvChecker<CarRacing<CarRacing-v2>>>>>
 
     ```
 
@@ -176,7 +176,7 @@ class CarRacing(gym.Env, EzPickle):
 
     ```python
     >>> import gymnasium as gym
-    >>> env = gym.make("CarRacing-v3", domain_randomize=True)
+    >>> env = gym.make("CarRacing-v2", domain_randomize=True)
 
     # normal reset, this changes the colour scheme by default
     >>> obs, _ = env.reset()
@@ -190,7 +190,6 @@ class CarRacing(gym.Env, EzPickle):
     ```
 
     ## Version History
-    - v2: Change truncation to termination when finishing the lap (1.0.0)
     - v1: Change track completion logic and add domain randomization (0.24.0)
     - v0: Original version
 
@@ -565,7 +564,6 @@ class CarRacing(gym.Env, EzPickle):
         step_reward = 0
         terminated = False
         truncated = False
-        info = {}
         if action is not None:  # First step without action, called from reset()
             self.reward -= 0.1
             # We actually don't want to count fuel spent, we want car to be faster.
@@ -574,18 +572,18 @@ class CarRacing(gym.Env, EzPickle):
             step_reward = self.reward - self.prev_reward
             self.prev_reward = self.reward
             if self.tile_visited_count == len(self.track) or self.new_lap:
-                # Termination due to finishing lap
-                terminated = True
-                info["lap_finished"] = True
+                # Truncation due to finishing lap
+                # This should not be treated as a failure
+                # but like a timeout
+                truncated = True
             x, y = self.car.hull.position
             if abs(x) > PLAYFIELD or abs(y) > PLAYFIELD:
                 terminated = True
-                info["lap_finished"] = False
                 step_reward = -100
 
         if self.render_mode == "human":
             self.render()
-        return self.state, step_reward, terminated, truncated, info
+        return self.state, step_reward, terminated, truncated, {}
 
     def render(self):
         if self.render_mode is None:

--- a/gymnasium/spaces/tuple.py
+++ b/gymnasium/spaces/tuple.py
@@ -47,14 +47,14 @@ class Tuple(Space[typing.Tuple[Any, ...]], typing.Sequence[Any]):
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return all(space.is_np_flattenable for space in self.spaces)
 
-    def seed(self, seed: int | tuple[int] | None = None) -> tuple[int, ...]:
+    def seed(self, seed: int | typing.Sequence[int] | None = None) -> tuple[int, ...]:
         """Seed the PRNG of this space and all subspaces.
 
         Depending on the type of seed, the subspaces will be seeded differently
 
         * ``None`` - All the subspaces will use a random initial seed
         * ``Int`` - The integer is used to seed the :class:`Tuple` space that is used to generate seed values for each of the subspaces. Warning, this does not guarantee unique seeds for all the subspaces.
-        * ``List`` - Values used to seed the subspaces. This allows the seeding of multiple composite subspaces ``[42, 54, ...]``.
+        * ``List`` / ``Tuple`` - Values used to seed the subspaces. This allows the seeding of multiple composite subspaces ``[42, 54, ...]``.
 
         Args:
             seed: An optional list of ints or int to seed the (sub-)spaces.

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -212,7 +212,7 @@ def play(
         >>> import gymnasium as gym
         >>> import numpy as np
         >>> from gymnasium.utils.play import play
-        >>> play(gym.make("CarRacing-v3", render_mode="rgb_array"),  # doctest: +SKIP
+        >>> play(gym.make("CarRacing-v2", render_mode="rgb_array"), # doctest: +SKIP
         ...     keys_to_action={
         ...         "w": np.array([0, 0.7, 0], dtype=np.float32),
         ...         "a": np.array([-1, 0, 0], dtype=np.float32),

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 
-from gymnasium import logger
+from gymnasium import Space, logger
 from gymnasium.core import ActType, Env, ObsType, RenderFrame
 from gymnasium.error import (
     AlreadyPendingCallError,
@@ -22,8 +22,10 @@ from gymnasium.error import (
     CustomSpaceError,
     NoAsyncCallError,
 )
+from gymnasium.spaces.utils import is_space_dtype_shape_equiv
 from gymnasium.vector.utils import (
     CloudpickleWrapper,
+    batch_differing_spaces,
     batch_space,
     clear_mpi_env_vars,
     concatenate,
@@ -98,6 +100,7 @@ class AsyncVectorEnv(VectorEnv):
             ]
             | None
         ) = None,
+        observation_mode: str | Space = "same",
     ):
         """Vectorized environment that runs multiple environments in parallel.
 
@@ -113,11 +116,15 @@ class AsyncVectorEnv(VectorEnv):
                 so for some environments you may want to have it set to ``False``.
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
+            observation_mode: Defines how environment observation spaces should be batched. 'same' defines that there should be ``n`` copies of identical spaces.
+                'different' defines that there can be multiple observation spaces with different parameters though requires the same shape and dtype,
+                warning, may raise unexpected errors. Passing a ``Tuple[Space, Space]`` object allows defining a custom ``single_observation_space`` and
+                ``observation_space``, warning, may raise unexpected errors.
 
         Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
             to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
-            from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.
+            from the code for ``_worker`` (or ``_async_worker``) method, and add changes.
 
         Raises:
             RuntimeError: If the observation space of some sub-environment does not match observation_space
@@ -128,6 +135,7 @@ class AsyncVectorEnv(VectorEnv):
         self.env_fns = env_fns
         self.shared_memory = shared_memory
         self.copy = copy
+        self.observation_mode = observation_mode
 
         self.num_envs = len(env_fns)
 
@@ -139,13 +147,30 @@ class AsyncVectorEnv(VectorEnv):
         self.metadata = dummy_env.metadata
         self.render_mode = dummy_env.render_mode
 
-        self.single_observation_space = dummy_env.observation_space
         self.single_action_space = dummy_env.action_space
-
-        self.observation_space = batch_space(
-            self.single_observation_space, self.num_envs
-        )
         self.action_space = batch_space(self.single_action_space, self.num_envs)
+
+        if isinstance(observation_mode, tuple) and len(observation_mode) == 2:
+            assert isinstance(observation_mode[0], Space)
+            assert isinstance(observation_mode[1], Space)
+            self.observation_space, self.single_observation_space = observation_mode
+        else:
+            if observation_mode == "same":
+                self.single_observation_space = dummy_env.observation_space
+                self.observation_space = batch_space(
+                    self.single_observation_space, self.num_envs
+                )
+            elif observation_mode == "different":
+                # the environment is created and instantly destroy, might cause issues for some environment
+                # but I don't believe there is anything else we can do, for users with issues, pre-compute the spaces and use the custom option.
+                env_spaces = [env().observation_space for env in self.env_fns]
+
+                self.single_observation_space = env_spaces[0]
+                self.observation_space = batch_differing_spaces(env_spaces)
+            else:
+                raise ValueError(
+                    f"Invalid `observation_mode`, expected: 'same' or 'different' or tuple of single and batch observation space, actual got {observation_mode}"
+                )
 
         dummy_env.close()
         del dummy_env
@@ -162,9 +187,7 @@ class AsyncVectorEnv(VectorEnv):
                 )
             except CustomSpaceError as e:
                 raise ValueError(
-                    "Using `shared_memory=True` in `AsyncVectorEnv` is incompatible with non-standard Gymnasium observation spaces (i.e. custom spaces inheriting from `gymnasium.Space`), "
-                    "and is only compatible with default Gymnasium spaces (e.g. `Box`, `Tuple`, `Dict`) for batching. "
-                    "Set `shared_memory=False` if you use custom observation spaces."
+                    "Using `AsyncVector(..., shared_memory=True)` caused an error, you can disable this feature with `shared_memory=False` however this is slower."
                 ) from e
         else:
             _obs_buffer = None
@@ -591,20 +614,33 @@ class AsyncVectorEnv(VectorEnv):
 
     def _check_spaces(self):
         self._assert_is_running()
-        spaces = (self.single_observation_space, self.single_action_space)
 
         for pipe in self.parent_pipes:
-            pipe.send(("_check_spaces", spaces))
+            pipe.send(
+                (
+                    "_check_spaces",
+                    (
+                        self.observation_mode,
+                        self.single_observation_space,
+                        self.single_action_space,
+                    ),
+                )
+            )
 
         results, successes = zip(*[pipe.recv() for pipe in self.parent_pipes])
         self._raise_if_errors(successes)
         same_observation_spaces, same_action_spaces = zip(*results)
 
         if not all(same_observation_spaces):
-            raise RuntimeError(
-                f"Some environments have an observation space different from `{self.single_observation_space}`. "
-                "In order to batch observations, the observation spaces from all environments must be equal."
-            )
+            if self.observation_mode == "same":
+                raise RuntimeError(
+                    "AsyncVectorEnv(..., observation_mode='same') however some of the sub-environments observation spaces are not equivalent. If this is intentional, use `observation_mode='different'` instead."
+                )
+            else:
+                raise RuntimeError(
+                    "AsyncVectorEnv(..., observation_mode='different' or custom space) however the sub-environment's observation spaces do not share a common shape and dtype."
+                )
+
         if not all(same_action_spaces):
             raise RuntimeError(
                 f"Some environments have an action space different from `{self.single_action_space}`. "
@@ -714,9 +750,20 @@ def _async_worker(
                 env.set_wrapper_attr(name, value)
                 pipe.send((None, True))
             elif command == "_check_spaces":
+                obs_mode, single_obs_space, single_action_space = data
+
                 pipe.send(
                     (
-                        (data[0] == observation_space, data[1] == action_space),
+                        (
+                            (
+                                single_obs_space == observation_space
+                                if obs_mode == "same"
+                                else is_space_dtype_shape_equiv(
+                                    single_obs_space, observation_space
+                                )
+                            ),
+                            single_action_space == action_space,
+                        ),
                         True,
                     )
                 )

--- a/gymnasium/vector/utils/__init__.py
+++ b/gymnasium/vector/utils/__init__.py
@@ -7,6 +7,7 @@ from gymnasium.vector.utils.shared_memory import (
     write_to_shared_memory,
 )
 from gymnasium.vector.utils.space_utils import (
+    batch_differing_spaces,
     batch_space,
     concatenate,
     create_empty_array,
@@ -16,6 +17,7 @@ from gymnasium.vector.utils.space_utils import (
 
 __all__ = [
     "batch_space",
+    "batch_differing_spaces",
     "iterate",
     "concatenate",
     "create_empty_array",

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -309,7 +309,7 @@ class FrameStackObservation(
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import FrameStackObservation
-        >>> env = gym.make("CarRacing-v3")
+        >>> env = gym.make("CarRacing-v2")
         >>> env = FrameStackObservation(env, stack_size=4)
         >>> env.observation_space
         Box(0, 255, (4, 96, 96, 3), uint8)

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -225,7 +225,7 @@ class FlattenObservation(
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import FlattenObservation
-        >>> env = gym.make("CarRacing-v3")
+        >>> env = gym.make("CarRacing-v2")
         >>> env.observation_space.shape
         (96, 96, 3)
         >>> env = FlattenObservation(env)
@@ -267,7 +267,7 @@ class GrayscaleObservation(
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import GrayscaleObservation
-        >>> env = gym.make("CarRacing-v3")
+        >>> env = gym.make("CarRacing-v2")
         >>> env.observation_space.shape
         (96, 96, 3)
         >>> grayscale_env = GrayscaleObservation(env)
@@ -345,7 +345,7 @@ class ResizeObservation(
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import ResizeObservation
-        >>> env = gym.make("CarRacing-v3")
+        >>> env = gym.make("CarRacing-v2")
         >>> env.observation_space.shape
         (96, 96, 3)
         >>> resized_env = ResizeObservation(env, (32, 32))
@@ -416,7 +416,7 @@ class ReshapeObservation(
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import ReshapeObservation
-        >>> env = gym.make("CarRacing-v3")
+        >>> env = gym.make("CarRacing-v2")
         >>> env.observation_space.shape
         (96, 96, 3)
         >>> reshape_env = ReshapeObservation(env, (24, 4, 96, 1, 3))

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -213,7 +213,7 @@ class FlattenObservation(VectorizeTransformObservation):
 
     Example:
         >>> import gymnasium as gym
-        >>> envs = gym.make_vec("CarRacing-v3", num_envs=3, vectorization_mode="sync")
+        >>> envs = gym.make_vec("CarRacing-v2", num_envs=3, vectorization_mode="sync")
         >>> obs, info = envs.reset(seed=123)
         >>> obs.shape
         (3, 96, 96, 3)
@@ -238,7 +238,7 @@ class GrayscaleObservation(VectorizeTransformObservation):
 
     Example:
         >>> import gymnasium as gym
-        >>> envs = gym.make_vec("CarRacing-v3", num_envs=3, vectorization_mode="sync")
+        >>> envs = gym.make_vec("CarRacing-v2", num_envs=3, vectorization_mode="sync")
         >>> obs, info = envs.reset(seed=123)
         >>> obs.shape
         (3, 96, 96, 3)
@@ -266,7 +266,7 @@ class ResizeObservation(VectorizeTransformObservation):
 
     Example:
         >>> import gymnasium as gym
-        >>> envs = gym.make_vec("CarRacing-v3", num_envs=3, vectorization_mode="sync")
+        >>> envs = gym.make_vec("CarRacing-v2", num_envs=3, vectorization_mode="sync")
         >>> obs, info = envs.reset(seed=123)
         >>> obs.shape
         (3, 96, 96, 3)
@@ -292,7 +292,7 @@ class ReshapeObservation(VectorizeTransformObservation):
 
     Example:
         >>> import gymnasium as gym
-        >>> envs = gym.make_vec("CarRacing-v3", num_envs=3, vectorization_mode="sync")
+        >>> envs = gym.make_vec("CarRacing-v2", num_envs=3, vectorization_mode="sync")
         >>> obs, info = envs.reset(seed=123)
         >>> obs.shape
         (3, 96, 96, 3)

--- a/tests/envs/registration/test_make.py
+++ b/tests/envs/registration/test_make.py
@@ -242,7 +242,7 @@ def test_make_human_rendering(register_rendering_testing_envs):
         TypeError,
         match=re.escape("got an unexpected keyword argument 'render'"),
     ):
-        gym.make("CarRacing-v3", render="human")
+        gym.make("CarRacing-v2", render="human")
 
     # This test checks that a user can create an environment without the metadata including the render mode
     with pytest.warns(

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -54,7 +54,7 @@ def test_carracing_domain_randomize():
     CarRacing DomainRandomize should have different colours at every reset.
     However, it should have same colours when `options={"randomize": False}` is given to reset.
     """
-    env: CarRacing = gym.make("CarRacing-v3", domain_randomize=True).unwrapped
+    env: CarRacing = gym.make("CarRacing-v2", domain_randomize=True).unwrapped
 
     road_color = env.road_color
     bg_color = env.bg_color

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -6,7 +6,13 @@ import pytest
 
 import gymnasium as gym
 from gymnasium.spaces import Box, Graph, Sequence, utils
+from gymnasium.spaces.utils import is_space_dtype_shape_equiv
 from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector.utils import (
+    create_shared_memory,
+    read_from_shared_memory,
+    write_to_shared_memory,
+)
 from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS
 
 
@@ -162,3 +168,40 @@ def test_unflatten_multidiscrete_error():
     value = np.array([0, 0])
     with pytest.raises(ValueError):
         utils.unflatten(gym.spaces.MultiDiscrete([1, 1]), value)
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_is_space_dtype_shape_equiv(space):
+    assert is_space_dtype_shape_equiv(space, space) is True
+
+
+@pytest.mark.parametrize("space_1", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_all_space_pairs_for_is_space_dtype_shape_equiv(space_1):
+    """Practically check that the `is_space_dtype_shape_equiv` works as expected for `shared_memory`."""
+    for space_2 in TESTING_SPACES:
+        compatible = is_space_dtype_shape_equiv(space_1, space_2)
+
+        if compatible:
+            try:
+                shared_memory = create_shared_memory(space_1, n=2)
+            except TypeError as err:
+                assert (
+                    "has a dynamic shape so its not possible to make a static shared memory."
+                    in str(err)
+                )
+                pytest.skip("Skipping space with dynamic shape")
+
+            space_1.seed(123)
+            space_2.seed(123)
+            sample_1 = space_1.sample()
+            sample_2 = space_2.sample()
+
+            write_to_shared_memory(space_1, 0, sample_1, shared_memory)
+            write_to_shared_memory(space_2, 1, sample_2, shared_memory)
+
+            read_sample_1, read_sample_2 = read_from_shared_memory(
+                space_1, shared_memory, n=2
+            )
+
+            assert data_equivalence(sample_1, read_sample_1)
+            assert data_equivalence(sample_2, read_sample_2)

--- a/tests/vector/test_observation_mode.py
+++ b/tests/vector/test_observation_mode.py
@@ -1,0 +1,121 @@
+import re
+from functools import partial
+
+import numpy as np
+import pytest
+
+from gymnasium.spaces import Box, Dict, Discrete
+from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.vector.utils import batch_differing_spaces
+from tests.testing_env import GenericTestEnv
+
+
+def create_env(obs_space):
+    return lambda: GenericTestEnv(observation_space=obs_space)
+
+
+# Test cases for both SyncVectorEnv and AsyncVectorEnv
+@pytest.mark.parametrize(
+    "vector_env_fn",
+    [SyncVectorEnv, AsyncVectorEnv, partial(AsyncVectorEnv, shared_memory=False)],
+    ids=[
+        "SyncVectorEnv",
+        "AsyncVectorEnv(shared_memory=True)",
+        "AsyncVectorEnv(shared_memory=False)",
+    ],
+)
+class TestVectorEnvObservationModes:
+
+    def test_invalid_observation_mode(self, vector_env_fn):
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                "Invalid `observation_mode`, expected: 'same' or 'different' or tuple of single and batch observation space, actual got invalid"
+            ),
+        ):
+            vector_env_fn(
+                [create_env(Box(low=0, high=1, shape=(5,))) for _ in range(3)],
+                observation_mode="invalid",
+            )
+
+    def test_obs_mode_same_different_spaces(self, vector_env_fn):
+        spaces = [Box(low=0, high=i, shape=(2,)) for i in range(1, 4)]
+        with pytest.raises(
+            (AssertionError, RuntimeError),
+            match="the sub-environments observation spaces are not equivalent. .*If this is intentional, use `observation_mode='different'` instead.",
+        ):
+            vector_env_fn(
+                [create_env(space) for space in spaces], observation_mode="same"
+            )
+
+    @pytest.mark.parametrize(
+        "observation_mode",
+        [
+            "different",
+            (
+                Box(
+                    low=0,
+                    high=np.repeat(np.arange(1, 4), 5).reshape((3, 5)),
+                    shape=(3, 5),
+                ),
+                Box(low=0, high=1, shape=(5,)),
+            ),
+        ],
+    )
+    def test_obs_mode_different_different_spaces(self, vector_env_fn, observation_mode):
+        spaces = [Box(low=0, high=i, shape=(5,)) for i in range(1, 4)]
+        envs = vector_env_fn(
+            [create_env(space) for space in spaces], observation_mode=observation_mode
+        )
+        assert envs.observation_space == batch_differing_spaces(spaces)
+        assert envs.single_observation_space == spaces[0]
+
+        envs.reset()
+        envs.step(envs.action_space.sample())
+        envs.close()
+
+    @pytest.mark.parametrize(
+        "observation_mode",
+        [
+            "different",
+            (Box(low=0, high=4, shape=(3, 5)), Box(low=0, high=4, shape=(5,))),
+        ],
+    )
+    def test_obs_mode_different_different_shapes(self, vector_env_fn, observation_mode):
+        spaces = [Box(low=0, high=1, shape=(i + 1,)) for i in range(3)]
+        with pytest.raises(
+            (AssertionError, RuntimeError),
+            # match=re.escape(
+            #     "Expected all Box.low shape to be equal, actually [(1,), (2,), (3,)]"
+            # ),
+        ):
+            vector_env_fn(
+                [create_env(space) for space in spaces],
+                observation_mode=observation_mode,
+            )
+
+    @pytest.mark.parametrize(
+        "observation_mode",
+        [
+            "same",
+            "different",
+            (Box(low=0, high=4, shape=(3, 5)), Box(low=0, high=4, shape=(5,))),
+        ],
+    )
+    def test_mixed_observation_spaces(self, vector_env_fn, observation_mode):
+        spaces = [
+            Box(low=0, high=1, shape=(3,)),
+            Discrete(5),
+            Dict({"a": Discrete(2), "b": Box(low=0, high=1, shape=(2,))}),
+        ]
+
+        with pytest.raises(
+            (AssertionError, RuntimeError),
+            # match=re.escape(
+            #     "Expects all spaces to be the same shape, actual types: [<class 'gymnasium.spaces.box.Box'>, <class 'gymnasium.spaces.discrete.Discrete'>, <class 'gymnasium.spaces.dict.Dict'>]"
+            # ),
+        ):
+            vector_env_fn(
+                [create_env(space) for space in spaces],
+                observation_mode=observation_mode,
+            )

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -1,5 +1,7 @@
 """Test the `SyncVectorEnv` implementation."""
 
+import re
+
 import numpy as np
 import pytest
 
@@ -139,7 +141,12 @@ def test_check_spaces_sync_vector_env():
     env_fns = [make_env("CartPole-v1", i) for i in range(8)]
     # FrozenLake-v1 - Discrete(16), action_space: Discrete(4)
     env_fns[1] = make_env("FrozenLake-v1", 1)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "SyncVectorEnv(..., observation_mode='same') however the sub-environments observation spaces are not equivalent."
+        ),
+    ):
         env = SyncVectorEnv(env_fns)
         env.close()
 

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -4,13 +4,20 @@ import copy
 import re
 from typing import Iterable
 
+import numpy as np
 import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
-from gymnasium.spaces import Tuple
+from gymnasium.spaces import Box, Tuple
 from gymnasium.utils.env_checker import data_equivalence
-from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
+from gymnasium.vector.utils import (
+    batch_differing_spaces,
+    batch_space,
+    concatenate,
+    create_empty_array,
+    iterate,
+)
 from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS, CustomSpace
 from tests.vector.utils.utils import is_rng_equal
 
@@ -68,13 +75,13 @@ def test_batch_space_deterministic(space: Space, n: int, base_seed: int):
     space_a = space
     space_a.seed(base_seed)
     space_b = copy.deepcopy(space_a)
-    is_rng_equal(space_a.np_random, space_b.np_random)
+    assert is_rng_equal(space_a.np_random, space_b.np_random)
     assert space_a.np_random is not space_b.np_random
 
     # Batch the spaces and check that the np_random are not reference equal
     space_a_batched = batch_space(space_a, n)
     space_b_batched = batch_space(space_b, n)
-    is_rng_equal(space_a_batched.np_random, space_b_batched.np_random)
+    assert is_rng_equal(space_a_batched.np_random, space_b_batched.np_random)
     assert space_a_batched.np_random is not space_b_batched.np_random
     # Create that the batched space is not reference equal to the origin spaces
     assert space_a.np_random is not space_a_batched.np_random
@@ -101,7 +108,7 @@ def test_batch_space_different_samples(space: Space, n: int, base_seed: int):
 
     batched_space = batch_space(space, n)
     assert space.np_random is not batched_space.np_random
-    is_rng_equal(space.np_random, batched_space.np_random)
+    assert is_rng_equal(space.np_random, batched_space.np_random)
 
     batched_sample = batched_space.sample()
     unbatched_samples = list(iterate(batched_space, batched_sample))
@@ -149,3 +156,68 @@ def test_custom_space():
 
     empty_array = create_empty_array(custom_space)
     assert empty_array is None
+
+
+@pytest.mark.parametrize(
+    "spaces,expected_space",
+    [
+        (
+            (
+                Box(low=0, high=1, shape=(2,), dtype=np.float32),
+                Box(low=2, high=np.array([3, 5], dtype=np.float32)),
+            ),
+            Box(low=np.array([[0, 0], [2, 2]]), high=np.array([[1, 1], [3, 5]])),
+        ),
+    ],
+)
+def test_varying_spaces(spaces: "list[Space]", expected_space):
+    """Test the batch spaces function."""
+    batched_space = batch_differing_spaces(spaces)
+    assert batched_space == expected_space
+
+    batch_samples = batched_space.sample()
+    for sub_space, sub_sample in zip(spaces, iterate(batched_space, batch_samples)):
+        assert sub_sample in sub_space
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+@pytest.mark.parametrize("n", [1, 3])
+def test_batch_differing_space_vs_batch_space(space, n):
+    """Test the batch_spaces and batch_space functions."""
+    batched_space = batch_space(space, n)
+    batched_spaces = batch_differing_spaces([copy.deepcopy(space) for _ in range(n)])
+
+    assert batched_space == batched_spaces, f"{batched_space=}, {batched_spaces=}"
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+@pytest.mark.parametrize("n", [1, 2, 5], ids=[f"n={n}" for n in [1, 2, 5]])
+@pytest.mark.parametrize(
+    "base_seed", [123, 456], ids=[f"seed={base_seed}" for base_seed in [123, 456]]
+)
+def test_batch_differing_spaces_deterministic(space: Space, n: int, base_seed: int):
+    """Tests the batched spaces are deterministic by using a copied version."""
+    # Copy the spaces and check that the np_random are not reference equal
+    space_a = space
+    space_a.seed(base_seed)
+    space_b = copy.deepcopy(space_a)
+    assert is_rng_equal(space_a.np_random, space_b.np_random)
+    assert space_a.np_random is not space_b.np_random
+
+    # Batch the spaces and check that the np_random are not reference equal
+    space_a_batched = batch_differing_spaces([space_a for _ in range(n)])
+    space_b_batched = batch_differing_spaces([space_b for _ in range(n)])
+    assert is_rng_equal(space_a_batched.np_random, space_b_batched.np_random)
+    assert space_a_batched.np_random is not space_b_batched.np_random
+    # Create that the batched space is not reference equal to the origin spaces
+    assert space_a.np_random is not space_a_batched.np_random
+
+    # Check that batched space a and b random number generator are not effected by the original space
+    space_a.sample()
+    space_a_batched_sample = space_a_batched.sample()
+    space_b_batched_sample = space_b_batched.sample()
+    for a_sample, b_sample in zip(
+        iterate(space_a_batched, space_a_batched_sample),
+        iterate(space_b_batched, space_b_batched_sample),
+    ):
+        assert data_equivalence(a_sample, b_sample)

--- a/tests/wrappers/test_normalize_observation.py
+++ b/tests/wrappers/test_normalize_observation.py
@@ -68,7 +68,7 @@ def test_update_running_mean_property():
 
 def test_normalize_obs_with_vector():
     def thunk():
-        env = gym.make("CarRacing-v3")
+        env = gym.make("CarRacing-v2")
         env = gym.wrappers.GrayscaleObservation(env)
         env = gym.wrappers.NormalizeObservation(env)
         return env

--- a/tests/wrappers/test_resize_observation.py
+++ b/tests/wrappers/test_resize_observation.py
@@ -47,7 +47,7 @@ def test_resize_observation_wrapper(env):
 
 @pytest.mark.parametrize("shape", ((10, 10), (20, 20), (60, 60), (100, 100)))
 def test_resize_shapes(shape: tuple[int, int]):
-    env = ResizeObservation(gym.make("CarRacing-v3"), shape)
+    env = ResizeObservation(gym.make("CarRacing-v2"), shape)
     assert env.observation_space == Box(
         low=0, high=255, shape=shape + (3,), dtype=np.uint8
     )
@@ -59,7 +59,7 @@ def test_resize_shapes(shape: tuple[int, int]):
 
 
 def test_invalid_input():
-    env = gym.make("CarRacing-v3")
+    env = gym.make("CarRacing-v2")
 
     with pytest.raises(AssertionError):
         ResizeObservation(env, ())

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -42,9 +42,9 @@ def custom_environments():
     (
         ("CustomDictEnv-v0", "FilterObservation", {"filter_keys": ["a"]}),
         ("CartPole-v1", "FlattenObservation", {}),
-        ("CarRacing-v3", "GrayscaleObservation", {}),
-        ("CarRacing-v3", "ResizeObservation", {"shape": (35, 45)}),
-        ("CarRacing-v3", "ReshapeObservation", {"shape": (96, 48, 6)}),
+        ("CarRacing-v2", "GrayscaleObservation", {}),
+        ("CarRacing-v2", "ResizeObservation", {"shape": (35, 45)}),
+        ("CarRacing-v2", "ReshapeObservation", {"shape": (96, 48, 6)}),
         (
             "CartPole-v1",
             "RescaleObservation",
@@ -53,7 +53,7 @@ def custom_environments():
                 "max_obs": np.array([1, np.inf, 1, np.inf]),
             },
         ),
-        ("CarRacing-v3", "DtypeObservation", {"dtype": np.int32}),
+        ("CarRacing-v2", "DtypeObservation", {"dtype": np.int32}),
         # ("CartPole-v1", "RenderObservation", {}),  # not implemented
         # ("CartPole-v1", "TimeAwareObservation", {}),  # not implemented
         # ("CartPole-v1", "FrameStackObservation", {}),  # not implemented


### PR DESCRIPTION
Recreated from original PR: https://github.com/Farama-Foundation/Gymnasium/pull/1140

# Description

In order to add Meta-World environments to use the Sync/Async Gymnasium methods, a change needed to be made in order to batch observations that have different low/high values.

This change allows the user to specify one of 3 modes for batching observations:

* 'same': current method of having the same observation space for all environments
* 'different': method that allows for different observation spaces to be batched together, given the observation spaces are the same siz...